### PR TITLE
.encode("base64") adds \n at the end of output

### DIFF
--- a/sample.credentials
+++ b/sample.credentials
@@ -1,5 +1,5 @@
 [allegro]
 api_key: [api key generated on allegro.pl]
 login: [allegro.pl login]
-password_enc: [password encoded by hashlib.sha256(password).digest().encode('base64')[
+password_enc: [password encoded by base64.b64encode(hashlib.sha256(password).digest())]
 country_code: [1 for PL]


### PR DESCRIPTION
another way:

```
hashlib.sha256(password).digest().encode("base64").strip()
```
